### PR TITLE
WIP: Fix Bug 2214451 - Running inside a container where rhsm.conf is missing on RHCOS, repo_ca_cert gets set to a bogus value: /etc/rhsm-host-host/ca/redhat-uep.pem

### DIFF
--- a/rhsm/rhsm-context.c
+++ b/rhsm/rhsm-context.c
@@ -369,6 +369,10 @@ rhsm_context_new (void)
       entitlement_cert_dir = rhsm_key_file_get_interpolated_string (conf, "rhsm", "entitlementCertDir", NULL);
     }
 
+  /* Check rhsm.conf exists */
+  if (!g_file_test (conf_file, G_FILE_TEST_EXISTS))
+    g_debug ("Not found config file %s", conf_file);
+
   return g_object_new (RHSM_TYPE_CONTEXT,
                        "conf-file", conf_file,
                        "baseurl", baseurl,
@@ -538,8 +542,9 @@ rhsm_context_constructed (GObject *object)
         }
     }
 
-  /* If we have conf coming from /etc/rhsm-host, most probably we need to replace /etc/rhsm */
-  if (g_str_has_prefix (ctx->conf_file, CONFIG_DIR_HOST))
+  /* If we have conf existed and coming from /etc/rhsm-host, most probably we need to replace /etc/rhsm. */
+  if (g_file_test (ctx->conf_file, G_FILE_TEST_EXISTS) && 
+      g_str_has_prefix (ctx->conf_file, CONFIG_DIR_HOST))
     {
      rhsm_utils_str_replace (&ctx->ca_cert_dir, CONFIG_DIR, CONFIG_DIR_HOST);
      rhsm_utils_str_replace (&ctx->repo_ca_cert, CONFIG_DIR, CONFIG_DIR_HOST);


### PR DESCRIPTION
This patch is to fix coreos image based on RHEL for entitled builds, and will not make any regression for ubi container(xerf to [comment](https://bugzilla.redhat.com/show_bug.cgi?id=2214451#c8)).

For entitlement build on OCP, and the workaround is to remove `/etc/rhsm-host`, see https://docs.openshift.com/container-platform/4.13/cicd/builds/running-entitled-builds.html#builds-running-entitled-builds-with-sharedsecret-objects_running-entitled-builds

For rhel-coreos base image we ship `subscription-manager-rhsm-certificates` (but not `subscription-manager`), if running in container the config file will be set by default `/etc/rhsm-host/rhsm.conf`(which does not exist, as it is shipped by subscription-manager), then we get the repo ca cert file is `/etc/rhsm-host/ca/redhat-uep.pem`.

According to code https://github.com/rpm-software-management/librhsm/blob/5e0674cf389f14174208641ec411ba7be448d5e3/rhsm/rhsm-context.c#L542, check conf is under `/etc/rhsm-host`, will update ca cert dir from `/etc/rhsm` to `/etc/rhsm-host`, and finally get `/etc/rhsm-host-host/ca/redhat-uep.pem`, the path is not correct and fail.

Before replace:
```conf=/etc/rhsm-host/rhsm.conf, ca=/etc/rhsm-host/ca, repo=/etc/rhsm-host/ca/redhat-uep.pem```
After replace:
```conf=/etc/rhsm-host/rhsm.conf, ca=/etc/rhsm-host-host/ca, repo=/etc/rhsm-host-host/ca/redhat-uep.pem```

Fix https://github.com/rpm-software-management/librhsm/issues/9 and https://bugzilla.redhat.com/show_bug.cgi?id=2214451