### PR TITLE
Stop replacing `/etc/rhsm-host/ca` to `/etc/rhsm-host-host/ca` if ca cert dir is already under `/etc/rhsm-host`

### DIFF
--- a/rhsm/rhsm-context.c
+++ b/rhsm/rhsm-context.c
@@ -538,8 +538,9 @@ rhsm_context_constructed (GObject *object)
         }
     }
 
-  /* If we have conf coming from /etc/rhsm-host, most probably we need to replace /etc/rhsm */
-  if (g_str_has_prefix (ctx->conf_file, CONFIG_DIR_HOST))
+  /* If ca cert dir is not under /etc/rhsm-host and conf coming from /etc/rhsm-host, 
+     most probably we need to replace /etc/rhsm */
+  if (!g_str_has_prefix (ctx->ca_cert_dir, CONFIG_DIR_HOST) && g_str_has_prefix (ctx->conf_file, CONFIG_DIR_HOST))
     {
      rhsm_utils_str_replace (&ctx->ca_cert_dir, CONFIG_DIR, CONFIG_DIR_HOST);
      rhsm_utils_str_replace (&ctx->repo_ca_cert, CONFIG_DIR, CONFIG_DIR_HOST);


### PR DESCRIPTION
This will not brake any existed logic, and the existed certificates
path, but will resolve entitlement issue for rhcos based container
image.

The error is like:
```
bash-5.1# rpm-ostree install libreswan
...
Curl error (77): Problem with the SSL CA cert (path? access rights?) for https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/repodata/repomd.xml [error setting certificate file: /etc/rhsm-host-host/ca/redhat-uep.pem]
```
Fixes https://issues.redhat.com/browse/OCPBUGS-11181, https://github.com/rpm-software-management/librhsm/issues/9