### PR TITLE
Fix unused parameter warnings

### DIFF
--- a/rhsm/rhsm-context.c
+++ b/rhsm/rhsm-context.c
@@ -698,6 +698,6 @@ rhsm_context_class_init (RHSMContextClass *klass)
 }
 
 static void
-rhsm_context_init (RHSMContext *ctx)
+rhsm_context_init (G_GNUC_UNUSED RHSMContext *ctx)
 {
 }

--- a/rhsm/rhsm-entitlement-certificate.c
+++ b/rhsm/rhsm-entitlement-certificate.c
@@ -359,6 +359,6 @@ rhsm_entitlement_certificate_class_init (RHSMEntitlementCertificateClass *klass)
 }
 
 static void
-rhsm_entitlement_certificate_init (RHSMEntitlementCertificate *cert)
+rhsm_entitlement_certificate_init (G_GNUC_UNUSED RHSMEntitlementCertificate *cert)
 {
 }

--- a/rhsm/rhsm-product-certificate.c
+++ b/rhsm/rhsm-product-certificate.c
@@ -487,6 +487,6 @@ rhsm_product_certificate_class_init (RHSMProductCertificateClass *klass)
 }
 
 static void
-rhsm_product_certificate_init (RHSMProductCertificate *cert)
+rhsm_product_certificate_init (G_GNUC_UNUSED RHSMProductCertificate *cert)
 {
 }


### PR DESCRIPTION
When building the code, warnigs likes this were printed:

    ../../home/test/librhsm/rhsm/rhsm-entitlement-certificate.c:362:64: warning: unused parameter ‘cert’ [-Wunused-parameter]
      362 | rhsm_entitlement_certificate_init (RHSMEntitlementCertificate *cert)
          |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~

This patch fixes them.