### PR TITLE
Fix const correctness of X509_EXTENSION_get_data() call

### DIFF
--- a/rhsm/rhsm-product-certificate.c
+++ b/rhsm/rhsm-product-certificate.c
@@ -25,6 +25,7 @@
 #include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
+#include <openssl/opensslv.h>
 
 #define X509_EXT_REDHAT_OID "1.3.6.1.4.1.2312.9"
 
@@ -109,8 +110,14 @@ x509_get_ext_data_by_oid (X509         *cert,
       return NULL;
     }
 
-  const X509_EXTENSION *ext = X509_get_ext (cert, loc);
-  ASN1_OCTET_STRING *octet_str = X509_EXTENSION_get_data (ext);
+#if OPENSSL_VERSION_MAJOR >= 4
+#define X509_QUAL const
+#else
+#define X509_QUAL
+#endif
+  X509_QUAL X509_EXTENSION *ext = X509_get_ext (cert, loc);
+  X509_QUAL ASN1_OCTET_STRING *octet_str = X509_EXTENSION_get_data (ext);
+#undef X509_QUAL
   if (octet_str == NULL)
     return NULL;
 


### PR DESCRIPTION
This fixes this warning:
    
        [4/5] cc -Irhsm/librhsm.so.0.p -Irhsm -I../../home/test/librhsm/rhsm -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/json-glib-1.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu11 -O0 -g -fPIC -pthread -DWITH_GZFILEOP -DRHSM_COMPILATION '-DG_LOG_DOMAIN="librhsm"' -MD -MQ rhsm/librhsm.so.0.p/rhsm-product-certificate.c.o -MF rhsm/librhsm.so.0.p/rhsm-product-certificate.c.o.d -o rhsm/librhsm.so.0.p/rhsm-product-certificate.c.o -c ../../home/test/librhsm/rhsm/rhsm-product-certificate.c
        ../../home/test/librhsm/rhsm/rhsm-product-certificate.c: In function ‘x509_get_ext_data_by_oid’:
        ../../home/test/librhsm/rhsm/rhsm-product-certificate.c:113:34: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
          113 |   ASN1_OCTET_STRING *octet_str = X509_EXTENSION_get_data (ext);
              |                                  ^~~~~~~~~~~~~~~~~~~~~~~
